### PR TITLE
Ensure consistent header.php files

### DIFF
--- a/types/blog-modern/header.php
+++ b/types/blog-modern/header.php
@@ -37,17 +37,13 @@
 					) ); ?>
 				<?php endif; ?>
 
-			<?php if ( has_nav_menu( 'main' ) ) : ?>
-				<nav id="site-navigation" class="main-navigation" role="navigation">
-					<?php wp_nav_menu( array( 'theme_location' => 'main' ) ); ?>
-				</nav><!-- #site-navigation -->
-			<?php endif; ?>
+				<?php get_template_part( 'components/top-navigation/top-navigation' ); ?>
 
 
 			<?php if ( is_active_sidebar( 'sidebar-1' ) ) {
 				get_sidebar();
 			} ?>
-			</div>
+		</div><!-- .slide-panel -->
 		<?php endif; ?>
 		<?php if ( is_home() && is_front_page() ) : ?>
 			<?php if ( get_header_image() ) : ?>

--- a/types/blog-traditional/header.php
+++ b/types/blog-traditional/header.php
@@ -31,35 +31,18 @@
 		if ( ! empty( $header_image ) ) { ?>
 			<div id="header-image" class="custom-header">
 				<div class="header-wrapper">
-					<div class="site-branding">
-						<?php if ( is_front_page() && is_home() ) : ?>
-							<h1 class="site-title"><a href="<?php echo esc_url( home_url( '/' ) ); ?>" rel="home"><?php bloginfo( 'name' ); ?></a></h1>
-						<?php else : ?>
-							<p class="site-title"><a href="<?php echo esc_url( home_url( '/' ) ); ?>" rel="home"><?php bloginfo( 'name' ); ?></a></p>
-						<?php endif; ?>
-						<p class="site-description"><?php bloginfo( 'description' ); ?></p>
-					</div><!-- .site-branding -->
+					<?php get_template_part( 'components/branding/branding' ); ?>
 				</div><!-- .header-wrapper -->
 				<img src="<?php header_image(); ?>" width="<?php echo get_custom_header()->width; ?>" height="<?php echo get_custom_header()->height; ?>" alt="">
 			</div><!-- #header-image .custom-header -->
 		<?php } else { ?>
-			<div class="site-branding">
-				<?php if ( is_front_page() && is_home() ) : ?>
-					<h1 class="site-title"><a href="<?php echo esc_url( home_url( '/' ) ); ?>" rel="home"><?php bloginfo( 'name' ); ?></a></h1>
-				<?php else : ?>
-					<p class="site-title"><a href="<?php echo esc_url( home_url( '/' ) ); ?>" rel="home"><?php bloginfo( 'name' ); ?></a></p>
-				<?php endif; ?>
-				<p class="site-description"><?php bloginfo( 'description' ); ?></p>
-			</div><!-- .site-branding -->
+			<?php get_template_part( 'components/branding/branding' ); ?>
 		<?php } ?>
 	</header><!-- #masthead -->
 
-	<?php theme_traditional_the_site_logo(); ?>
+	<?php get_template_part( 'components/site-logo/site-logo' ); ?>
 
-	<nav id="site-navigation" class="main-navigation" role="navigation">
-	<button class="menu-toggle" aria-controls="primary-menu" aria-expanded="false"><?php esc_html_e( 'Primary Menu', 'theme_traditional' ); ?></button>
-	<?php wp_nav_menu( array( 'theme_location' => 'primary', 'menu_id' => 'primary-menu' ) ); ?>
-</nav><!-- #site-navigation -->
+	<?php get_template_part( 'components/top-navigation/top-navigation' ); ?>
 
 	</header><!-- #masthead -->
 

--- a/types/business/header.php
+++ b/types/business/header.php
@@ -26,9 +26,9 @@
 
 		<?php get_template_part( 'components/branding/branding' ); ?>
 
-		<?php get_template_part( 'compoonents/site-logo/site-logo' ); ?>
+		<?php get_template_part( 'components/site-logo/site-logo' ); ?>
 
-		<?php get_template_part( 'compoonents/top-navigation/top-navigation' ); ?>
+		<?php get_template_part( 'components/top-navigation/top-navigation' ); ?>
 
 	</header><!-- #masthead -->
 

--- a/types/portfolio/header.php
+++ b/types/portfolio/header.php
@@ -31,27 +31,18 @@
 		if ( ! empty( $header_image ) ) { ?>
 			<div id="header-image" class="custom-header">
 				<div class="header-wrapper">
-					<div class="site-branding">
-						<h1 class="site-title"><a href="<?php echo esc_url( home_url( '/' ) ); ?>" rel="home"><?php bloginfo( 'name' ); ?></a></h1>
-						<h2 class="site-description"><?php bloginfo( 'description' ); ?></h2>
-					</div><!-- .site-branding -->
+					<?php get_template_part( 'components/branding/branding' ); ?>
 				</div><!-- .header-wrapper -->
 				<img src="<?php header_image(); ?>" width="<?php echo get_custom_header()->width; ?>" height="<?php echo get_custom_header()->height; ?>" alt="">
 			</div><!-- #header-image .custom-header -->
 		<?php } else { ?>
-			<div class="site-branding">
-				<h1 class="site-title"><a href="<?php echo esc_url( home_url( '/' ) ); ?>" rel="home"><?php bloginfo( 'name' ); ?></a></h1>
-				<h2 class="site-description"><?php bloginfo( 'description' ); ?></h2>
-			</div><!-- .site-branding -->
+			<?php get_template_part( 'components/branding/branding' ); ?>
 		<?php } ?>
 	</header><!-- #masthead -->
 
-	<?php component_s_the_site_logo(); ?>
+	<?php get_template_part( 'components/site-logo/site-logo' ); ?>
 
-	<nav id="site-navigation" class="main-navigation" role="navigation">
-	<button class="menu-toggle" aria-controls="primary-menu" aria-expanded="false"><?php esc_html_e( 'Primary Menu', 'theme_traditional' ); ?></button>
-	<?php wp_nav_menu( array( 'theme_location' => 'primary', 'menu_id' => 'primary-menu' ) ); ?>
-</nav><!-- #site-navigation -->
+	<?php get_template_part( 'components/top-navigation/top-navigation' ); ?>
 
 	</header><!-- #masthead -->
 


### PR DESCRIPTION
I started getting confused between all the various files while working on this, so I'd appreciate a second set of eyes. 

In particular, I wasn't able to componentise `blog-modern/header.php` much at all—this is due in part to it having a different structure and requiring different markup for the navigation component.

Ideally, I think it would make sense to componentise all elements within this file, so it's in line with all other theme types, and use consistent (componentised) markup for the site navigation. This would make it more consistent with other types and also mean that all php editing would be done in the `/components` directory, which (I believe) is the aim here.

Looking through the header files, I think there's opportunity to further componentise and simplify them:

* custom header image
* social nav

It'd be nice to see that implemented, or at least reviewed, prior to this being merged.

Fixes #101; should fix #100.