### PR TITLE
Update menu ID and file header.

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * components functions and definitions
+ * Theme functions and definitions
  *
  * @package Components
  */
@@ -42,7 +42,7 @@ function components_setup() {
 
 	// This theme uses wp_nav_menu() in one location.
 	register_nav_menus( array(
-		'top' => esc_html__( 'Top Menu', 'components' ),
+		'primary' => esc_html__( 'Primary Menu', 'components' ),
 		'social'  => __( 'Social Links Menu', 'components' ),
 	) );
 


### PR DESCRIPTION
This ensures that the primary menu works as expected, and also removes a stray `components` instance in the file comments. (See #141 for the latter.)

Along with five other non-master PRs, this fixes #148.