### PR TITLE
fix strict comparison issue in comments.php file; resolve #199

### DIFF
--- a/comments.php
+++ b/comments.php
@@ -36,7 +36,7 @@ if ( post_password_required() ) {
 
 	<?php
 		// If comments are closed and there are comments, let's leave a little note, shall we?
-		if ( ! comments_open() && '0' != get_comments_number() && post_type_supports( get_post_type(), 'comments' ) ) :
+		if ( ! comments_open() && get_comments_number() && post_type_supports( get_post_type(), 'comments' ) ) :
 	?>
 		<p class="no-comments"><?php esc_html_e( 'Comments are closed.', 'components' ); ?></p>
 	<?php endif; ?>


### PR DESCRIPTION
In `comments.php` file line 39, there is `'0' != get_comments_number()`. It can be simplified to simply `get_comments_number()`. This will also fix strict comparison issue in sniffer. 