### PR TITLE
Issue #201 fixing template part slug

### DIFF
--- a/page-templates/template-front.php
+++ b/page-templates/template-front.php
@@ -9,8 +9,8 @@ get_header(); ?>
 
 	<div id="primary" class="content-area">
 		<main id="main" class="site-main" role="main">
-			<?php get_template_part( 'components/content', 'hero' ); ?>
-			<?php get_template_part( 'components/testimonials' ); ?>
+			<?php get_template_part( 'components/content-hero/content', 'hero' ); ?>
+			<?php get_template_part( 'components/testimonials/testimonials' ); ?>
 		</main>
 	</div>
 


### PR DESCRIPTION
the get_template_part slug doesn't exist and is missing the subdirector - content-hero and testimonials. See issue #201 