### PR TITLE
strict comparison for get_post_type() 

### DIFF
--- a/components/content-search/content-search.php
+++ b/components/content-search/content-search.php
@@ -13,7 +13,7 @@
 	<header class="entry-header">
 		<?php the_title( sprintf( '<h2 class="entry-title"><a href="%s" rel="bookmark">', esc_url( get_permalink() ) ), '</a></h2>' ); ?>
 
-		<?php if ( 'post' == get_post_type() ) : ?>
+		<?php if ( 'post' === get_post_type() ) : ?>
 		<div class="entry-meta">
 			<?php components_posted_on(); ?>
 		</div><!-- .entry-meta -->

--- a/components/content/content.php
+++ b/components/content/content.php
@@ -11,7 +11,7 @@
 	<header class="entry-header">
 		<?php the_title( sprintf( '<h2 class="entry-title"><a href="%s" rel="bookmark">', esc_url( get_permalink() ) ), '</a></h2>' ); ?>
 
-		<?php if ( 'post' == get_post_type() ) : ?>
+		<?php if ( 'post' === get_post_type() ) : ?>
 		<div class="entry-meta">
 			<?php components_posted_on(); ?>
 		</div><!-- .entry-meta -->


### PR DESCRIPTION
Currently there is `'post' == get_post_type()`. It'd better if we use strict comparision. like `'post' === get_post_type()`
