### PR TITLE
Classic blog: use correct package headers.

### DIFF
--- a/header.php
+++ b/header.php
@@ -4,7 +4,7 @@
  *
  * Displays all of the <head> section and everything up till <div id="content">
  *
- * @package theme-traditional
+ * @package Components
  */
 
 ?><!DOCTYPE html>

--- a/sidebar.php
+++ b/sidebar.php
@@ -2,7 +2,7 @@
 /**
  * The sidebar containing the main widget area.
  *
- * @package theme-traditional
+ * @package Components
  */
 
 if ( is_active_sidebar( 'sidebar-1' ) ) : ?>


### PR DESCRIPTION
Noticed that these files are still using an old package header, so it isn't being replaced in generated themes.