### PR TITLE
Remove search form component.

### DIFF
--- a/components/search-form/search-form.php
+++ b/components/search-form/search-form.php
@@ -1,7 +1,0 @@
-<form role="search" method="get" class="search-form" action="<?php echo esc_url( home_url( '/' ) ); ?>">
-	<label>
-		<span class="screen-reader-text"><?php _ex( 'Search for:', 'label', 'components' ); ?></span>
-		<input type="search" class="search-field" placeholder="<?php echo esc_attr_x( 'Search &hellip;', 'placeholder', 'components' ); ?>" value="<?php echo esc_attr( get_search_query() ); ?>" name="s">
-	</label>
-	<input type="submit" class="search-submit" value="<?php echo esc_attr_x( 'Search', 'submit button', 'components' ); ?>">
-</form>

--- a/search-form.php
+++ b/search-form.php
@@ -1,9 +1,0 @@
-<?php
-/**
- * The template for displaying search forms
- *
- * @package Components
- */
-?>
-
-<?php get_template_part( 'components/search-form/search-form.php' ); ?>


### PR DESCRIPTION
This would fix #213 by removing the unused search form component.

Alternatively this could be fixed by renaming `search-form.php` to `searchform.php` but there doesn't seem to be much purpose, given that its output is identical to the HTML5 core output. Themes would likely be better off modifying the output using pure CSS/JS.