### PR TITLE
Fixed Top Menu Location

### DIFF
--- a/components/top-navigation/top-navigation.php
+++ b/components/top-navigation/top-navigation.php
@@ -1,4 +1,4 @@
 <nav id="site-navigation" class="main-navigation" role="navigation">
 	<button class="menu-toggle" aria-controls="top-menu" aria-expanded="false"><?php esc_html_e( 'Top Menu', 'components' ); ?></button>
-	<?php wp_nav_menu( array( 'theme_location' => 'top', 'menu_id' => 'top-menu' ) ); ?>
+	<?php wp_nav_menu( array( 'theme_location' => 'top-menu', 'menu_id' => 'top-menu' ) ); ?>
 </nav><!-- #site-navigation -->


### PR DESCRIPTION
The theme location set for top menu was only "top" it should be "top-menu". Please fix