### PR TITLE
Replace spaces with tabs from config files to keep format consistent.

### DIFF
--- a/configs/type-magazine.json
+++ b/configs/type-magazine.json
@@ -1,9 +1,9 @@
 {
-  "replacement_files": [
-    "index.php",
-    "inc/jetpack.php"
-  ],
-  "components": [
-    "features/featured-content"
-  ]
+	"replacement_files": [
+		"index.php",
+		"inc/jetpack.php"
+	],
+	"components": [
+		"features/featured-content"
+	]
 }

--- a/configs/type-portfolio.json
+++ b/configs/type-portfolio.json
@@ -1,17 +1,17 @@
 {
-  "replacement_files": [
-    "header.php",
-    "functions.php",
-    "inc/jetpack.php"
-  ],
-  "sass_replace": [
-    "_components.scss",
-    "style.scss"
-  ],
-  "components": [
-    "features/portfolio"
-  ],
-  "templates": [
-    "frontpage-portfolio.php"
-  ]
+	"replacement_files": [
+		"header.php",
+		"functions.php",
+		"inc/jetpack.php"
+	],
+	"sass_replace": [
+		"_components.scss",
+		"style.scss"
+	],
+	"components": [
+		"features/portfolio"
+	],
+	"templates": [
+		"frontpage-portfolio.php"
+	]
 }


### PR DESCRIPTION
The magazine and portfolio types had spaces in them. This commit replaces the spaces with tabs, to keep the format consistent with the other type config files.