### PR TITLE
Fix escaping in Social Links Menu Text

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -43,7 +43,7 @@ function components_setup() {
 	// This theme uses wp_nav_menu() in one location.
 	register_nav_menus( array(
 		'top-menu' => esc_html__( 'Top Menu', 'components' ),
-		'social'  => __( 'Social Links Menu', 'components' ),
+		'social'   => esc_html__( 'Social Links Menu', 'components' ),
 	) );
 
 	/*


### PR DESCRIPTION
As I can see in other Github Issues, Social Links Menu is probably going to be deprecated soon in favor of Jetpack's Social Menu feature. But is there any specific reason we are not escaping the text of "Social Links Menu" here: https://github.com/Automattic/theme-components/blob/master/functions.php#L46 ? I just pushed a small fix for that. :) 

Cheers!