### PR TITLE
Update `readme.txt` file.

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -32,5 +32,5 @@ Components includes support for Jetpack's Infinite Scroll as well as other featu
 
 == Credits ==
 
-* Based on Components http://components.underscores.me/, (C) 2015-2016 Automattic, Inc., [GPLv2 or later](https://www.gnu.org/licenses/gpl-2.0.html)
+* Based on https://github.com/Automattic/theme-components/, (C) 2015-2016 Automattic, Inc., [GPLv2 or later](https://www.gnu.org/licenses/gpl-2.0.html)
 * normalize.css http://necolas.github.io/normalize.css/, (C) 2012-2016 Nicolas Gallagher and Jonathan Neal, [MIT](http://opensource.org/licenses/MIT)

--- a/readme.txt
+++ b/readme.txt
@@ -1,15 +1,13 @@
 === Components ===
 
-Contributors: automattic
-Tags: translation-ready, custom-background, theme-options, custom-menu, post-formats, threaded-comments
+Contributors:
+Tags:
 
-Requires at least: 4.0
-Tested up to: 4.4
+Requires at least:
+Tested up to:
 Stable tag: 1.0.0
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
-
-A custom starter theme called Components.
 
 == Description ==
 
@@ -25,11 +23,11 @@ Hi. I'm a starter theme called Components. I'm a theme meant for hacking so don'
 
 = Does this theme support any plugins? =
 
-Components includes support for Jetpack's Infinite Scroll and Site Logos, as well as other features.
+Components includes support for Jetpack's Infinite Scroll as well as other features.
 
 == Changelog ==
 
-= 1.0 - May 12 2015 =
+= 1.0 - [Date] =
 * Initial release
 
 == Credits ==


### PR DESCRIPTION
* This removes some info that would need to be constantly updated, but leaves fields there for theme authors to fill out.
* Also removes main line that would get altered by Generator anyway.
* Remove word `Components` so generator does not replace it. We don't want it replaced in the credits.

Fixes #109