### PR TITLE
Single column layout on mobile

### DIFF
--- a/assets/stylesheets/components/_navigation-top.scss
+++ b/assets/stylesheets/components/_navigation-top.scss
@@ -48,7 +48,7 @@
 			left: auto;
 		}
 	}
-	
+
 	li {
 		float: left;
 		position: relative;
@@ -57,7 +57,7 @@
 		&.focus > a {
 		}
 	}
-	
+
 	a {
 		display: block;
 		text-decoration: none;
@@ -82,7 +82,7 @@
 	margin-right: 5px;
 }
 
-@media screen and (min-width: 37.5em) {
+@media screen and (min-width: #{$breakpoint_tablet}) {
 	.menu-toggle {
 		display: none;
 	}

--- a/assets/stylesheets/layout/_content-sidebar.scss
+++ b/assets/stylesheets/layout/_content-sidebar.scss
@@ -1,4 +1,4 @@
-@media screen and (min-width: 37.5em) {
+@media screen and (min-width: #{$breakpoint_tablet}) {
   .content-area {
   	float: left;
   	margin: 0 (-$size_site-sidebar) 0 0;

--- a/assets/stylesheets/layout/_content-sidebar.scss
+++ b/assets/stylesheets/layout/_content-sidebar.scss
@@ -1,20 +1,22 @@
-.content-area {
-	float: left;
-	margin: 0 (-$size_site-sidebar) 0 0;
-	width: $size_site-main;
-}
+@media screen and (min-width: 37.5em) {
+  .content-area {
+  	float: left;
+  	margin: 0 (-$size_site-sidebar) 0 0;
+  	width: $size_site-main;
+  }
 
-.site-main {
-	margin: 0 $size_site-sidebar 0 0;
-}
+  .site-main {
+  	margin: 0 $size_site-sidebar 0 0;
+  }
 
-.site-content .widget-area {
-	float: right;
-	overflow: hidden;
-	width: $size_site-sidebar;
-}
+  .site-content .widget-area {
+  	float: right;
+  	overflow: hidden;
+  	width: $size_site-sidebar;
+  }
 
-.site-footer {
-	clear: both;
-	width: $size_site-main;
+  .site-footer {
+  	clear: both;
+  	width: $size_site-main;
+  }
 }

--- a/assets/stylesheets/layout/_sidebar-content.scss
+++ b/assets/stylesheets/layout/_sidebar-content.scss
@@ -1,4 +1,4 @@
-@media screen and (min-width: 37.5em) {
+@media screen and (min-width: #{$breakpoint_tablet}) {
   .content-area {
   	float: right;
   	margin: 0 0 0 (-$size_site-sidebar);

--- a/assets/stylesheets/layout/_sidebar-content.scss
+++ b/assets/stylesheets/layout/_sidebar-content.scss
@@ -1,20 +1,22 @@
-.content-area {
-	float: right;
-	margin: 0 0 0 (-$size_site-sidebar);
-	width: $size_site-main;
-}
+@media screen and (min-width: 37.5em) {
+  .content-area {
+  	float: right;
+  	margin: 0 0 0 (-$size_site-sidebar);
+  	width: $size_site-main;
+  }
 
-.site-main {
-	margin: 0 0 0 $size_site-sidebar;
-}
+  .site-main {
+  	margin: 0 0 0 $size_site-sidebar;
+  }
 
-.site-content .widget-area {
-	float: left;
-	overflow: hidden;
-	width: $size_site-sidebar;
-}
+  .site-content .widget-area {
+  	float: left;
+  	overflow: hidden;
+  	width: $size_site-sidebar;
+  }
 
-.site-footer {
-	clear: both;
-	width: $size_site-main;
+  .site-footer {
+  	clear: both;
+  	width: $size_site-main;
+  }
 }

--- a/assets/stylesheets/variables/_structure.scss
+++ b/assets/stylesheets/variables/_structure.scss
@@ -1,2 +1,4 @@
 $size_site-main: 100%;
 $size_site-sidebar: 25%;
+
+$breakpoint_tablet: 37.5em;

--- a/style.css
+++ b/style.css
@@ -721,25 +721,27 @@ body {
   /* Fallback for when there is no custom background color defined. */
 }
 
-.content-area {
-  float: left;
-  margin: 0 -25% 0 0;
-  width: 100%;
-}
+@media screen and (min-width: 37.5em) {
+    .content-area {
+      float: left;
+      margin: 0 -25% 0 0;
+      width: 100%;
+    }
 
-.site-main {
-  margin: 0 25% 0 0;
-}
+    .site-main {
+      margin: 0 25% 0 0;
+    }
 
-.site-content .widget-area {
-  float: right;
-  overflow: hidden;
-  width: 25%;
-}
+    .site-content .widget-area {
+      float: right;
+      overflow: hidden;
+      width: 25%;
+    }
 
-.site-footer {
-  clear: both;
-  width: 100%;
+    .site-footer {
+      clear: both;
+      width: 100%;
+    }
 }
 
 /*--------------------------------------------------------------


### PR DESCRIPTION
I noticed that components-generated themes are showing content in two columns, regardless of screen size. I'm not sure if this is by design or by oversight, but adding a simple media query here would give a better default behaviour and encourage a mobile-first approach to CSS styles.

Before:
![screen shot 2016-08-22 at 12 03 50](https://cloud.githubusercontent.com/assets/376315/17854284/6544ca40-6869-11e6-8252-358f39d3d8f2.png)

...and after:
![screen shot 2016-08-22 at 12 04 35](https://cloud.githubusercontent.com/assets/376315/17854283/6507008e-6869-11e6-85ec-5692cd26f009.png)

For consistency, I've used the 37.5em breakpoint used to trigger the mobile menu. Since that number is now used in a few places, I've also created a variable for it so it's easily adapted to the users' preference. That's a separate commit in case you'd prefer to leave the value manually coded—I just always use mixins and variables for breakpoints myself. 😄 
