### PR TITLE
Rename size variables for consistency with other variables.

### DIFF
--- a/assets/stylesheets/components/_header-fullscreen-image.scss
+++ b/assets/stylesheets/components/_header-fullscreen-image.scss
@@ -1,7 +1,7 @@
 .entry-wrapper {
   display: block;
   margin: 0 auto;
-  width: $size_site-main;
+  width: $size__site-main;
 }
 
 .feature-header {

--- a/assets/stylesheets/layout/_content-sidebar.scss
+++ b/assets/stylesheets/layout/_content-sidebar.scss
@@ -1,20 +1,20 @@
 .content-area {
 	float: left;
-	margin: 0 (-$size_site-sidebar) 0 0;
-	width: $size_site-main;
+	margin: 0 (-$size__site-sidebar) 0 0;
+	width: $size__site-main;
 }
 
 .site-main {
-	margin: 0 $size_site-sidebar 0 0;
+	margin: 0 $size__site-sidebar 0 0;
 }
 
 .site-content .widget-area {
 	float: right;
 	overflow: hidden;
-	width: $size_site-sidebar;
+	width: $size__site-sidebar;
 }
 
 .site-footer {
 	clear: both;
-	width: $size_site-main;
+	width: $size__site-main;
 }

--- a/assets/stylesheets/layout/_sidebar-content.scss
+++ b/assets/stylesheets/layout/_sidebar-content.scss
@@ -1,20 +1,20 @@
 .content-area {
 	float: right;
-	margin: 0 0 0 (-$size_site-sidebar);
-	width: $size_site-main;
+	margin: 0 0 0 (-$size__site-sidebar);
+	width: $size__site-main;
 }
 
 .site-main {
-	margin: 0 0 0 $size_site-sidebar;
+	margin: 0 0 0 $size__site-sidebar;
 }
 
 .site-content .widget-area {
 	float: left;
 	overflow: hidden;
-	width: $size_site-sidebar;
+	width: $size__site-sidebar;
 }
 
 .site-footer {
 	clear: both;
-	width: $size_site-main;
+	width: $size__site-main;
 }

--- a/assets/stylesheets/variables/_structure.scss
+++ b/assets/stylesheets/variables/_structure.scss
@@ -1,2 +1,2 @@
-$size_site-main: 100%;
-$size_site-sidebar: 25%;
+$size__site-main: 100%;
+$size__site-sidebar: 25%;

--- a/types/magazine/assets/stylesheets/layout/_content-sidebar-sidebar.scss
+++ b/types/magazine/assets/stylesheets/layout/_content-sidebar-sidebar.scss
@@ -1,20 +1,20 @@
 .content-area {
 	float: left;
-	width: $size_site-main;
+	width: $size__site-main;
 }
 .site-main {
-	margin: 0 ($size_site-sidebar*2) 0 0;
+	margin: 0 ($size__site-sidebar*2) 0 0;
 }
 .site-content .widget-area {
 	float: left;
-	margin: 0 0 0 (-$size_site-sidebar*2);
+	margin: 0 0 0 (-$size__site-sidebar*2);
 	overflow: hidden;
-	width: $size_site-sidebar;
+	width: $size__site-sidebar;
 }
 .site-content #tertiary.widget-area {
-	margin: 0 0 0 (-$size_site-sidebar);
+	margin: 0 0 0 (-$size__site-sidebar);
 }
 .site-footer {
 	clear: both;
-	width: $size_site-main;
+	width: $size__site-main;
 }

--- a/types/magazine/assets/stylesheets/layout/_sidebar-content-sidebar.scss
+++ b/types/magazine/assets/stylesheets/layout/_sidebar-content-sidebar.scss
@@ -1,20 +1,20 @@
 .content-area {
 	float: left;
-	width: $size_site-main;
+	width: $size__site-main;
 }
 .site-main {
-	margin: 0 $size_site-sidebar;
+	margin: 0 $size__site-sidebar;
 }
 .site-content .widget-area {
 	float: left;
-	margin: 0 0 0 (-$size_site-main);
+	margin: 0 0 0 (-$size__site-main);
 	overflow: hidden;
-	width: $size_site-sidebar;
+	width: $size__site-sidebar;
 }
 .site-content #tertiary.widget-area {
 	float: right;
 }
 .site-footer {
 	clear: both;
-	width: $size_site-main;
+	width: $size__site-main;
 }

--- a/types/magazine/assets/stylesheets/layout/_sidebar-sidebar-content.scss
+++ b/types/magazine/assets/stylesheets/layout/_sidebar-sidebar-content.scss
@@ -1,17 +1,17 @@
 .content-area {
 	float: right;
-	margin: 0 0 0 (-$size_site-sidebar*2);
-	width: $size_site-main;
+	margin: 0 0 0 (-$size__site-sidebar*2);
+	width: $size__site-main;
 }
 .site-main {
-	margin: 0 0 0 ($size_site-sidebar*2);
+	margin: 0 0 0 ($size__site-sidebar*2);
 }
 .site-content .widget-area {
 	float: left;
 	overflow: hidden;
-	width: $size_site-sidebar;
+	width: $size__site-sidebar;
 }
 .site-footer {
 	clear: both;
-	width: $size_site-main;
+	width: $size__site-main;
 }


### PR DESCRIPTION
Most sass variables used follow this naming convention: `$prefix__variable-name`, using two underscores (`$color__whatever`, `$font__whatever`).

Size variables are currently using only one underscore (`$size_whatever`), making things a bit inconsistent. It's also not consistent with how the variables were named in _s: https://github.com/Automattic/_s/blob/master/sass/variables-site/_structure.scss

Making the variable names consistent makes it less likely that theme builders will get confused and use the wrong ones. 
