### PR TITLE
Correct overly-aggressive default margins on figure elements.

### DIFF
--- a/assets/stylesheets/shared/_media.scss
+++ b/assets/stylesheets/shared/_media.scss
@@ -20,7 +20,7 @@ object {
 }
 
 .wp-caption {
-	margin-bottom: 1.5em;
+	margin: 1em 0 1.5em;
 	max-width: 100%;
 
 	img[class*="wp-image-"] {
@@ -30,6 +30,21 @@ object {
 	.wp-caption-text {
 		margin: 0.8075em 0;
 	}
+}
+
+/* Ensure center-aligned captions center-align properly. */
+.wp-caption.aligncenter {
+		margin-left: auto;
+		margin-right: auto;
+}
+
+/* Give some padding to floated elements, to prevent them butting up against text. */
+.wp-caption.alignleft {
+		margin-right: 20px;
+}
+
+.wp-caption.alignright {
+		margin-left: 20px;
 }
 
 .wp-caption-text {

--- a/style.css
+++ b/style.css
@@ -35,13 +35,13 @@ Nicolas Gallagher and Jonathan Neal http://necolas.github.com/normalize.css/
 # Navigation
 # Links
 # Layout
-	## Posts
-	## Pages
+  ## Posts
+  ## Pages
 # Comments
 # Widgets
 # Infinite scroll
 # Media
-	## Galleries
+  ## Galleries
 --------------------------------------------------------------*/
 /*--------------------------------------------------------------
 # Normalize
@@ -854,7 +854,7 @@ object {
 }
 
 .wp-caption {
-  margin-bottom: 1.5em;
+  margin: 1em 0 1.5em;
   max-width: 100%;
 }
 .wp-caption img[class*="wp-image-"] {
@@ -866,6 +866,19 @@ object {
   margin: 0.8075em 0;
 }
 
+/* Ensure center-aligned captions center-align properly. */
+.wp-caption.aligncenter {
+  margin-left: auto;
+  margin-right: auto;
+}
+
+/* Give some padding to floated elements, to prevent them butting up against text. */
+.wp-caption.alignleft {
+  margin-right: 20px;
+}
+.wp-caption.alignright {
+  margin-left: 20px;
+}
 .wp-caption-text {
   text-align: center;
 }


### PR DESCRIPTION
Normalize.css introduces a default 40px left and right margin on figure elements. This leads to overlapping issues on smaller screens, were the images will break the page width and introduce horizontal scrolling. No good!

This fix attempts to provide a more sensible default behaviour to account for different situations. The default figure element is given a left and right margin of 0. Centre-aligned figures use the 'auto' margin value. Left- and right-aligned captions inherit a little bit of margin (20px instead of 40) in order to avoid butting up against text, but are otherwise aligned with the edge of the text.

This provides a much better default and avoids any issues with horizontal scrolling.

Before:
<img width="1252" alt="screen shot 2016-09-18 at 11 25 29" src="https://cloud.githubusercontent.com/assets/376315/18996343/de3bd920-8727-11e6-9dda-54b9790054d1.png">

After:
<img width="425" alt="screenshot 2016-09-30 15 53 46" src="https://cloud.githubusercontent.com/assets/376315/18996369/ff33c782-8727-11e6-92bc-5b34bc7c7c81.png">

Note: this was a bit weird to test because of #292, but when the sidebar is hidden it makes a lot more sense! 

Also, https://github.com/Automattic/_s/pull/910 resolves the same issue in a similar way, but lacks the margin on left- and right-aligned captions to prevent text from butting up against the image.
