### PR TITLE
Remove Period From File Header 

### DIFF
--- a/404.php
+++ b/404.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * The template for displaying 404 pages (not found).
+ * The template for displaying 404 pages (not found)
  *
  * @link https://codex.wordpress.org/Creating_an_Error_404_Page
  *

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,7 +22,7 @@ file a bug, and we'll make sure it's in the right spot.
 If you find a bug or would like something added to the Components library, create a new issue! To create a new issue:
 
 1. **Search** existing issues first to ensure your issue hasn't already been reported.
-2. **Create** the issue. If it's a bug, provide steps to recreate the issue. (Attaching a video or screenshot is a great way to visually show what you're seeing. If your issue is an enhancement, attach a mockup or sketch to explain your idea.
+2. **Create** the issue. If it's a bug, provide steps to recreate the issue. (Attaching a video or screenshot is a great way to visually show what you're seeing.) If your issue is an enhancement, attach a mockup or sketch to explain your idea.
 3. **Pull Request** If you have found a bug and can fix it, attach a pull request to your issue! See below for more details on submitting PRs.
 
 ## Feature requests
@@ -107,13 +107,15 @@ To close an issue in a commit message, use a [keyword](https://help.github.com/a
 : `fixes #123`.
 
 Here's an example of a great commit message:
-`Improve widget performance by adding more weevils`.
+
+```
+Improve widget performance by adding more weevils.
 
 This adds six extra weevils to our vermin stack, effectively freeing up some
-of our older, rustier-kneed widgets for glue manufacturing. `Fixes #123.
-See also #666, #21`.
+of our older, rustier-kneed widgets for glue manufacturing. Fixes #123. See also #666, #21.
+```
 
 **IMPORTANT**: By submitting a patch, you agree to allow the project owner to
 license your work under the same license as that used by the project.
 
-Thanks for helping make the theme pattern library better!
+Thanks for helping make Components better!

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -107,12 +107,11 @@ To close an issue in a commit message, use a [keyword](https://help.github.com/a
 : `fixes #123`.
 
 Here's an example of a great commit message:
-`Improve widget performance by adding more weevils.
+`Improve widget performance by adding more weevils`.
 
 This adds six extra weevils to our vermin stack, effectively freeing up some
 of our older, rustier-kneed widgets for glue manufacturing. Fixes #123.
 See also #666, #21.
-`
 
 **IMPORTANT**: By submitting a patch, you agree to allow the project owner to
 license your work under the same license as that used by the project.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -97,7 +97,7 @@ project:
 
 The first line of your commit should be a short (fewer than 50 characters)
 summary of what your commit does. Commit messages should be capitalised and use
-the imperative mood: "fix bug", not "fixed bug" or "fixes bug."  
+the imperative mood: "Fix Bug", not "fixed bug" or "fixes bug."  
 
 To add further information or context, enter a blank new line and start a new
 paragraph below, wrapping lines so they don't get too long.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -110,8 +110,8 @@ Here's an example of a great commit message:
 `Improve widget performance by adding more weevils`.
 
 This adds six extra weevils to our vermin stack, effectively freeing up some
-of our older, rustier-kneed widgets for glue manufacturing. Fixes #123.
-See also #666, #21.
+of our older, rustier-kneed widgets for glue manufacturing. `Fixes #123.
+See also #666, #21`.
 
 **IMPORTANT**: By submitting a patch, you agree to allow the project owner to
 license your work under the same license as that used by the project.

--- a/archive.php
+++ b/archive.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * The template for displaying archive pages.
+ * The template for displaying archive pages
  *
  * @link https://codex.wordpress.org/Template_Hierarchy
  *

--- a/comments.php
+++ b/comments.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * The template for displaying comments.
+ * The template for displaying comments
  *
  * This is the template that displays the area of the page that contains both the current comments
  * and the comment form.

--- a/components/features/hero-image/content-hero.php
+++ b/components/features/hero-image/content-hero.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * The template used for displaying hero content.
+ * The template used for displaying hero content
  *
  * @package Components
  */

--- a/components/features/portfolio/portfolio.php
+++ b/components/features/portfolio/portfolio.php
@@ -1,5 +1,6 @@
 <?php
-/* The template for displaying portfolio items
+/** 
+ * The template for displaying portfolio items
  *
  * @package Components
  */

--- a/components/features/portfolio/single-jetpack-portfolio.php
+++ b/components/features/portfolio/single-jetpack-portfolio.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * The Template for displaying all single projects.
+ * The Template for displaying all single projects
  *
  * @package Components
  */

--- a/components/features/testimonials/archive-jetpack-testimonial.php
+++ b/components/features/testimonials/archive-jetpack-testimonial.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * The template for displaying the Testimonials archive page.
+ * The template for displaying the Testimonials archive page
  *
  * @package Components
  */

--- a/components/features/testimonials/content-testimonials.php
+++ b/components/features/testimonials/content-testimonials.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * The template used for displaying testimonials.
+ * The template used for displaying testimonials
  *
  * @package Components
  */

--- a/footer.php
+++ b/footer.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * The template for displaying the footer.
+ * The template for displaying the footer
  *
  * Contains the closing of the #content div and all content after.
  *

--- a/functions.php
+++ b/functions.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Components functions and definitions.
+ * Components functions and definitions
  *
  * @link https://developer.wordpress.org/themes/basics/theme-functions/
  *

--- a/header.php
+++ b/header.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * The header for our theme.
+ * The header for our theme
  *
  * This is the template that displays all of the <head> section and everything up until <div id="content">
  *

--- a/inc/customizer.php
+++ b/inc/customizer.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Components Theme Customizer.
+ * Components Theme Customizer
  *
  * @package Components
  */

--- a/inc/extras.php
+++ b/inc/extras.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Custom functions that act independently of the theme templates.
+ * Custom functions that act independently of the theme templates
  *
  * Eventually, some of the functionality here could be replaced by core features.
  *

--- a/inc/jetpack.php
+++ b/inc/jetpack.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Jetpack Compatibility File.
+ * Jetpack Compatibility File
  *
  * @link https://jetpack.me/
  *

--- a/inc/template-tags.php
+++ b/inc/template-tags.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Custom template tags for this theme.
+ * Custom template tags for this theme
  *
  * Eventually, some of the functionality here could be replaced by core features.
  *

--- a/inc/wpcom.php
+++ b/inc/wpcom.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * WordPress.com-specific functions and definitions.
+ * WordPress.com-specific functions and definitions
  *
  * This file is centrally included from `wp-content/mu-plugins/wpcom-theme-compat.php`.
  *

--- a/index.php
+++ b/index.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * The main template file.
+ * The main template file
  *
  * This is the most generic template file in a WordPress theme
  * and one of the two required files for a theme (the other being style.css).

--- a/page.php
+++ b/page.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * The template for displaying all pages.
+ * The template for displaying all pages
  *
  * This is the template that displays all pages by default.
  * Please note that this is the WordPress construct of pages

--- a/search.php
+++ b/search.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * The template for displaying search results pages.
+ * The template for displaying search results pages
  *
  * @link https://developer.wordpress.org/themes/basics/template-hierarchy/#search-result
  *

--- a/sidebar.php
+++ b/sidebar.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * The sidebar containing the main widget area.
+ * The sidebar containing the main widget area
  *
  * @link https://developer.wordpress.org/themes/basics/template-files/#template-partials
  *

--- a/single.php
+++ b/single.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * The template for displaying all single posts.
+ * The template for displaying all single posts
  *
  * @link https://developer.wordpress.org/themes/basics/template-hierarchy/#single-post
  *

--- a/types/blog-classic/functions.php
+++ b/types/blog-classic/functions.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * components functions and definitions.
+ * components functions and definitions
  *
  * @link https://developer.wordpress.org/themes/basics/theme-functions/
  *

--- a/types/blog-classic/header.php
+++ b/types/blog-classic/header.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * The header for our theme.
+ * The header for our theme
  *
  * This is the template that displays all of the <head> section and everything up until <div id="content">
  *

--- a/types/blog-classic/sidebar.php
+++ b/types/blog-classic/sidebar.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * The sidebar containing the main widget area.
+ * The sidebar containing the main widget area
  *
  * @link https://developer.wordpress.org/themes/basics/template-files/#template-partials
  *

--- a/types/blog-modern/archive.php
+++ b/types/blog-modern/archive.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * The template for displaying archive pages.
+ * The template for displaying archive pages
  *
  * @link https://codex.wordpress.org/Template_Hierarchy
  *

--- a/types/blog-modern/functions.php
+++ b/types/blog-modern/functions.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * components functions and definitions.
+ * components functions and definitions
  *
  * @link https://developer.wordpress.org/themes/basics/theme-functions/
  *

--- a/types/blog-modern/header.php
+++ b/types/blog-modern/header.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * The header for our theme.
+ * The header for our theme
  *
  * This is the template that displays all of the <head> section and everything up until <div id="content">
  *

--- a/types/blog-modern/index.php
+++ b/types/blog-modern/index.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * The main template file.
+ * The main template file
  *
  * This is the most generic template file in a WordPress theme
  * and one of the two required files for a theme (the other being style.css).

--- a/types/blog-modern/page.php
+++ b/types/blog-modern/page.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * The template for displaying all pages.
+ * The template for displaying all pages
  *
  * This is the template that displays all pages by default.
  * Please note that this is the WordPress construct of pages

--- a/types/blog-modern/search.php
+++ b/types/blog-modern/search.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * The template for displaying search results pages.
+ * The template for displaying search results pages
  *
  * @link https://developer.wordpress.org/themes/basics/template-hierarchy/#search-result
  *

--- a/types/blog-modern/single.php
+++ b/types/blog-modern/single.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * The template for displaying all single posts.
+ * The template for displaying all single posts
  *
  * @link https://developer.wordpress.org/themes/basics/template-hierarchy/#single-post
  *

--- a/types/business/functions.php
+++ b/types/business/functions.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * components functions and definitions.
+ * components functions and definitions
  *
  * @link https://developer.wordpress.org/themes/basics/theme-functions/
  *

--- a/types/business/inc/jetpack.php
+++ b/types/business/inc/jetpack.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Jetpack Compatibility File.
+ * Jetpack Compatibility File
  *
  * @link https://jetpack.me/
  *

--- a/types/magazine/archive.php
+++ b/types/magazine/archive.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * The template for displaying archive pages.
+ * The template for displaying archive pages
  *
  * @link https://codex.wordpress.org/Template_Hierarchy
  *

--- a/types/magazine/functions.php
+++ b/types/magazine/functions.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Components functions and definitions.
+ * Components functions and definitions
  *
  * @link https://developer.wordpress.org/themes/basics/theme-functions/
  *

--- a/types/magazine/inc/jetpack.php
+++ b/types/magazine/inc/jetpack.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Jetpack Compatibility File.
+ * Jetpack Compatibility File
  *
  * @link https://jetpack.me/
  *

--- a/types/magazine/index.php
+++ b/types/magazine/index.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * The main template file.
+ * The main template file
  *
  * This is the most generic template file in a WordPress theme
  * and one of the two required files for a theme (the other being style.css).

--- a/types/magazine/page.php
+++ b/types/magazine/page.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * The template for displaying all pages.
+ * The template for displaying all pages
  *
  * This is the template that displays all pages by default.
  * Please note that this is the WordPress construct of pages

--- a/types/magazine/search.php
+++ b/types/magazine/search.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * The template for displaying search results pages.
+ * The template for displaying search results pages
  *
  * @link https://developer.wordpress.org/themes/basics/template-hierarchy/#search-result
  *

--- a/types/magazine/sidebar-2.php
+++ b/types/magazine/sidebar-2.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * The sidebar containing the second widget area.
+ * The sidebar containing the second widget area
  *
  * @link https://developer.wordpress.org/themes/basics/template-files/#template-partials
  *

--- a/types/magazine/single.php
+++ b/types/magazine/single.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * The template for displaying all single posts.
+ * The template for displaying all single posts
  *
  * @link https://developer.wordpress.org/themes/basics/template-hierarchy/#single-post
  *

--- a/types/portfolio/functions.php
+++ b/types/portfolio/functions.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * components functions and definitions.
+ * components functions and definitions
  *
  * @link https://developer.wordpress.org/themes/basics/theme-functions/
  *

--- a/types/portfolio/header.php
+++ b/types/portfolio/header.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * The header for our theme.
+ * The header for our theme
  *
  * This is the template that displays all of the <head> section and everything up until <div id="content">
  *

--- a/types/portfolio/inc/jetpack.php
+++ b/types/portfolio/inc/jetpack.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Jetpack Compatibility File.
+ * Jetpack Compatibility File
  *
  * @link https://jetpack.me/
  *


### PR DESCRIPTION
According to [WordPress PHP Documentation Standards ](https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/php/#6-file-headers) there shouldn't be period after the file header

Fixes #302 
