### PR TITLE
Use the_tags() rather than get_the_tag_list()

### DIFF
--- a/inc/template-tags.php
+++ b/inc/template-tags.php
@@ -51,12 +51,8 @@ function components_entry_footer() {
 		if ( $categories_list && components_categorized_blog() ) {
 			printf( '<span class="cat-links">' . esc_html__( 'Posted in %1$s', 'components' ) . '</span>', $categories_list ); // WPCS: XSS OK.
 		}
-
-		/* translators: used between list items, there is a space after the comma */
-		$tags_list = get_the_tag_list( '', esc_html__( ', ', 'components' ) );
-		if ( $tags_list ) {
-			printf( '<span class="tags-links">' . esc_html__( 'Tagged %1$s', 'components' ) . '</span>', $tags_list ); // WPCS: XSS OK.
-		}
+		
+		the_tags( sprintf( '<span class="tags-links">%1$s ', esc_html__( 'Tagged', 'components' ) ), ', ', '</span>' );
 	}
 
 	if ( ! is_single() && ! post_password_required() && ( comments_open() || get_comments_number() ) ) {

--- a/inc/template-tags.php
+++ b/inc/template-tags.php
@@ -52,7 +52,8 @@ function components_entry_footer() {
 			printf( '<span class="cat-links">' . esc_html__( 'Posted in %1$s', 'components' ) . '</span>', $categories_list ); // WPCS: XSS OK.
 		}
 		
-		the_tags( sprintf( '<span class="tags-links">%1$s ', esc_html__( 'Tagged', 'components' ) ), ', ', '</span>' );
+		/* translators: used between list items, there is a space after the comma */
+		the_tags( sprintf( '<span class="tags-links">%1$s ', esc_html__( 'Tagged', 'components' ) ), esc_html__( ', ', 'components' ), '</span>' );
 	}
 
 	if ( ! is_single() && ! post_password_required() && ( comments_open() || get_comments_number() ) ) {


### PR DESCRIPTION
The latter causes fatal errors on output if WP_Error is returned and not checked for. the_tags() automatically accounts for the error.

I am not sure if we need to wrap the comma in a gettext function as well, or if this is fine for translation purposes.