### PR TITLE
doctype change uppercase to lowercase

### DIFF
--- a/header.php
+++ b/header.php
@@ -9,7 +9,7 @@
  * @package Components
  */
 
-?><!DOCTYPE html>
+?><!doctype html>
 <html <?php language_attributes(); ?>>
 <head>
 <meta charset="<?php bloginfo( 'charset' ); ?>">


### PR DESCRIPTION
it doesn't really matter, but for consistency doctype can be in lowercase. besides, [html5boilerplate is also changed to lowercase](https://github.com/h5bp/html5-boilerplate/issues/1522)